### PR TITLE
Fix server start up errors with some locales

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/server/application/AppleLocale.java
+++ b/server/src/main/java/org/uiautomation/ios/server/application/AppleLocale.java
@@ -52,7 +52,7 @@ public class AppleLocale {
     	corrected= "ja";
     }
     for (Locale l : Locale.getAvailableLocales()) {
-      if (l.toString().equals(corrected)) {
+      if (l.toString().equals(corrected.replace('-','_'))) {
         return l;
       }
     }
@@ -61,7 +61,6 @@ public class AppleLocale {
         return l;
       }
     }
-
     for (Locale l : Locale.getAvailableLocales()) {
       if (l.getDisplayLanguage().equals(corrected)) {
         return l;
@@ -69,6 +68,16 @@ public class AppleLocale {
     }
     if ("zh-Hant".equals(lprojname)) {
       return Locale.CHINESE;
+    }
+    if ("zh-Hans".equals(lprojname)) {
+      return Locale.CHINESE;
+    }
+    if ("nb".equals(lprojname)) {
+      for (Locale l : Locale.getAvailableLocales()) {
+        if (l.getDisplayCountry().equals("Norway")) {
+          return l;
+        }
+      }
     }
     if ("he".equals(lprojname)) {
       for (Locale l : Locale.getAvailableLocales()) {


### PR DESCRIPTION
Fix server start up errors with some locales. The server wasn't starting due to some missing locales. Once this patch is in it worked. I'm not sure the '-' to '_' replacement is correct, but all the locales on my system had underscores. Also, traditional and simplified Chinese are different but decided to leave it be for now.
