### PR TITLE
Make sendKeys and setValue send the whole string, not just characters

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/SendKeysNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/SendKeysNHandler.java
@@ -32,12 +32,19 @@ public class SendKeysNHandler extends UIAScriptHandler {
     super(driver, request);
     try {
       JSONArray array = request.getPayload().getJSONArray("value");
-      String value = array.getString(0);
+      StringBuilder b = new StringBuilder();
 
-      String corrected = value.replaceAll("\\\\", "\\\\\\\\");
+      if (array != null) {
+        int len = array.length();
+        for (int i = 0; i < len; i++) {
+          b.append(array.get(i).toString());
+        }
+      }
+
+      String corrected = b.toString().replaceAll("\\\\", "\\\\\\\\");
       corrected = corrected.replaceAll("\\n", "\\\\n");
 
-      if (value.contains("\\t")) {
+      if (corrected.contains("\\t")) {
         throw new WebDriverException("cannot tab on the ios keyboard.");
       }
 

--- a/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/SetValueNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/SetValueNHandler.java
@@ -33,8 +33,16 @@ public class SetValueNHandler extends UIAScriptHandler {
     boolean useNativeEvents = (Boolean) getConfiguration("nativeEvents");
     try {
       JSONArray array = request.getPayload().getJSONArray("value");
-      String value = array.getString(0);
-      String corrected = value.replaceAll("\\\\", "\\\\\\\\");
+      StringBuilder b = new StringBuilder();
+
+      if (array != null) {
+        int len = array.length();
+        for (int i = 0; i < len; i++) {
+          b.append(array.get(i).toString());
+        }
+      }
+
+      String corrected = b.toString().replaceAll("\\\\", "\\\\\\\\");
       corrected = corrected.replaceAll("\\n", "\\\\n");
       corrected = corrected.replaceAll("\\t", "\\\\t");
 


### PR DESCRIPTION
Looking at http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/element/:id/value and http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/keys the spec says the commands take an array of characters and should flatten them into a string before sending. What the code currently does is takes the first array element (which is a character). This doesn't seem to spec, and this patch fixes it.

I would imagine this is a client-breaking change (though I tested with my client) and I am new to the code so I'd like extra scrutiny on this

Fixed issue #12
