### PR TITLE
Ensure the CFBundleName is both non-null and non-blank before preferring...

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/server/application/APPIOSApplication.java
+++ b/server/src/main/java/org/uiautomation/ios/server/application/APPIOSApplication.java
@@ -427,7 +427,7 @@ public class APPIOSApplication {
   public String getApplicationName() {
     String name = getMetadata(IOSCapabilities.BUNDLE_NAME);
     String displayName = getMetadata(IOSCapabilities.BUNDLE_DISPLAY_NAME);
-    return name != null ? name : displayName;
+    return (name != null) && ! name.trim().isEmpty() ? name : displayName;
 
   }
 


### PR DESCRIPTION
... it over the CFBundleDisplayName value.

Fixes #32: Application name is blank.
