### PR TITLE
Better window handling and use UUID when matching devices.

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/server/Device.java
+++ b/server/src/main/java/org/uiautomation/ios/server/Device.java
@@ -42,6 +42,12 @@ public abstract class Device {
       }
       // TODO freynaud check device family.
     }
+
+    if (desiredCapabilities.getDeviceUUID() != null &&
+        !desiredCapabilities.getDeviceUUID().equals(deviceCapability.getDeviceUUID())) {
+      return false;
+    }
+
     return true;
   }
 

--- a/server/src/main/java/org/uiautomation/ios/server/RealDevice.java
+++ b/server/src/main/java/org/uiautomation/ios/server/RealDevice.java
@@ -95,7 +95,7 @@ public class RealDevice extends Device {
     //res.setCapability(IOSCapabilities.UI_SDK_VERSION, iosVersion);
     //res.setCapability(IOSCapabilities.DEVICE, type);
     //res.setCapability(IOSCapabilities.VARIATION, DeviceVariation.valueOf(this.productType.replace(",", "")));
-    //res.setCapability(IOSCapabilities.UUID, uuid);
+    res.setCapability(IOSCapabilities.UUID, uuid);
     return res;
   }
 

--- a/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/GetWindowHandlesNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/server/command/uiautomation/GetWindowHandlesNHandler.java
@@ -21,8 +21,9 @@ import org.uiautomation.ios.UIAModels.configuration.WorkingMode;
 import org.uiautomation.ios.UIAModels.predicate.TypeCriteria;
 import org.uiautomation.ios.communication.WebDriverLikeRequest;
 import org.uiautomation.ios.server.IOSServerManager;
-import org.uiautomation.ios.server.ServerSideSession;
+import org.uiautomation.ios.server.InstrumentsBackedNativeIOSDriver;
 import org.uiautomation.ios.server.command.BaseNativeCommandHandler;
+import org.uiautomation.ios.server.instruments.NoInstrumentsImplementationAvailable;
 import org.uiautomation.ios.wkrdp.message.WebkitPage;
 
 import java.util.HashSet;
@@ -36,13 +37,12 @@ public class GetWindowHandlesNHandler extends BaseNativeCommandHandler {
 
   @Override
   public Response handle() throws Exception {
-
-    ServerSideSession sss = getServer().getSession(getRequest().getSession());
-
     Set<String> handles = new HashSet<String>();
     handles.add(WorkingMode.Native.toString());
 
-    if (sss.getDualDriver().getNativeDriver().findElements(new TypeCriteria(UIAWebView.class)).size() > 0) {
+    InstrumentsBackedNativeIOSDriver nativeDriver = getNativeDriver();
+    if ((nativeDriver.getInstruments() instanceof NoInstrumentsImplementationAvailable) ||
+        (nativeDriver.findElements(new TypeCriteria(UIAWebView.class)).size() > 0)) {
       for (WebkitPage page : getWebDriver().getPages()) {
         handles.add(WorkingMode.Web + "_" + page.getPageId());
       }

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/RemoteIOSWebDriver.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/RemoteIOSWebDriver.java
@@ -45,6 +45,7 @@ import org.uiautomation.ios.wkrdp.model.RemoteWebElement;
 import org.uiautomation.ios.wkrdp.model.RemoteWebNativeBackedElement;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -246,10 +247,10 @@ public class RemoteIOSWebDriver {
         protocol.connect(bundleId);
         sync.waitForSimToSendPages();
         log.fine("bundleId=" + bundleId);
-        switchTo(getPages().get(0));
+        switchTo(Collections.max(getPages()));
         if (getPages().size() > 1) {
           log.warning("Application started, but already have " + getPages().size()
-                      + " webviews. Connecting to the first one.");
+                      + " webviews. Connecting to the one with highest page id.");
         }
         return;
       }

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/WebKitNotificationListener.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/WebKitNotificationListener.java
@@ -27,6 +27,7 @@ import org.uiautomation.ios.wkrdp.message.WebkitApplication;
 import org.uiautomation.ios.wkrdp.message.WebkitPage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -102,21 +103,10 @@ public class WebKitNotificationListener implements MessageListener {
           if (m.getPages().size() == 0) {
             throw new WebDriverException(m.getPages().size() + " new pages.");
           }
-          // TODO there can be more than one 'new' UIWebView, picking the first one for now.
-          WebkitPage newOne = m.getPages().get(0);
 
-          boolean debug = true;
-          int index;
-          if (debug == true){
-            index = 0;
-          }else {
-            index =
-                driver.getPages().size() == 0 ? 0
-                                              :
-                session.getDualDriver().getRemoteWebDriver().getWindowHandleIndex()
-                + 1;
-          }
-          pages.add(index, newOne);
+          // TODO there can be more than one 'new' UIWebView, picking the max one for now.
+          WebkitPage newOne = Collections.max(m.getPages());
+          pages.addAll(m.getPages());
 
           driver.setPages(pages);
 


### PR DESCRIPTION
Better window handling in ios-driver. (1) Make getWindowHandles() work when instruments is not available. (2) Make ios-driver robust to running in Safari when it has already-open tabs.
