### PR TITLE
Use the four-inch mouseover area size with another four-inch variant.

### DIFF
--- a/server/src/main/resources/inspector/ide.js
+++ b/server/src/main/resources/inspector/ide.js
@@ -60,7 +60,7 @@ configure = function (d, v, o) {
     var SCREEN_TO_TOP_IPHONE = 118;
     var SCREEN_TO_LEFT_IPHONE = 24;
 
-    if (variation === 'Retina4') {
+    if (variation === 'Retina4' || variation === 'iPhoneRetina_4inch') {
         SCREEN_IPHONE_H = 568;
         SCREEN_IPHONE_W = 320;
         FRAME_IPHONE_W = 386;


### PR DESCRIPTION
I think the whole idea will need to be rethought for resizable simulators. Hopefully there's a way to to get the screen configuration from Instruments (probably UIATarget.localTarget().rect()) to remove this duplication.
