### PR TITLE
Xcode betas don't have old model iPhone simulators, making iPhone 5s...

### DIFF
--- a/common/src/main/java/org/uiautomation/ios/communication/device/DeviceVariation.java
+++ b/common/src/main/java/org/uiautomation/ios/communication/device/DeviceVariation.java
@@ -117,9 +117,10 @@ public enum DeviceVariation {
   
   public static DeviceVariation getCompatibleVersion(DeviceType device, String sdkVersion) {
       boolean isSdk7OrNewer = (new IOSVersion(sdkVersion)).isGreaterOrEqualTo("7.0");
+      boolean isSdk8OrNewer = (new IOSVersion(sdkVersion)).isGreaterOrEqualTo("8.0");
       switch (device) {
         case iphone:
-          return isSdk7OrNewer? Retina4 : Regular;
+          return isSdk8OrNewer? iPhone5s : (isSdk7OrNewer? Retina4 : Regular);
         case ipad:
           return isSdk7OrNewer? Retina : Regular;
       }


### PR DESCRIPTION
Xcode betas don't have old model iPhone simulators, making iPhone 5s
