### PR TITLE
Fallback methods for discovering UIAAlert buttons.

### DIFF
--- a/server/src/main/resources/instruments-js/UIAAlert.js
+++ b/server/src/main/resources/instruments-js/UIAAlert.js
@@ -35,7 +35,7 @@ UIAAlert.prototype.accept = function () {
     var button = this.defaultButton();
     if (button.type() === "UIAElementNil") {
         var buttons = this.buttons();
-        button = buttons[OK];
+        button = buttons["OK"];
         if (button.type() === "UIAElementNil" && buttons.length > 0) {
             button = buttons[buttons.length - 1];
             if (button.type() === "UIAElementNil") {

--- a/server/src/main/resources/instruments-js/UIAAlert.js
+++ b/server/src/main/resources/instruments-js/UIAAlert.js
@@ -13,7 +13,11 @@ UIAAlert.prototype.dismiss = function () {
         log("cancel is not there,trying default.");
         button = this.defaultButton();
         if (button.type() === "UIAElementNil") {
-            throw new UIAutomationException("this alert doesn't have the normal buttons.", 7);
+            log("default button missing, trying zeroth button");
+            button = this.buttons()[0];
+            if (button.type() === "UIAElementNil") {
+                throw new UIAutomationException("this alert doesn't have the normal buttons.", 7);
+            }
         }
     } else {
         log("cancel found");
@@ -30,7 +34,14 @@ UIAAlert.prototype.dismiss = function () {
 UIAAlert.prototype.accept = function () {
     var button = this.defaultButton();
     if (button.type() === "UIAElementNil") {
-        throw new UIAutomationException("this alert doesn't have a default normal buttons.", 7);
+        var buttons = this.buttons();
+        button = buttons[OK];
+        if (button.type() === "UIAElementNil" && buttons.length > 0) {
+            button = buttons[buttons.length - 1];
+            if (button.type() === "UIAElementNil") {
+                throw new UIAutomationException("this alert doesn't have a default normal buttons.", 7);
+            }
+        }
     }
     button.tap();
     UIATarget.localTarget().delay(0.5);


### PR DESCRIPTION
UIAAlerts on iOS 8 often don't have the normal buttons. This PR adds fallback methods for trying to locate the correct button for both dismissing and accepting alerts.
