### PR TITLE
Fix unit test failure

### DIFF
--- a/common/src/test/java/org/uiautomation/ios/utils/IOSVersionTest.java
+++ b/common/src/test/java/org/uiautomation/ios/utils/IOSVersionTest.java
@@ -14,7 +14,7 @@
 
 package org.uiautomation.ios.utils;
 
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class IOSVersionTest {

--- a/grid/pom.xml
+++ b/grid/pom.xml
@@ -58,6 +58,12 @@
         <!--</dependency>-->
 
         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>jetty-repacked</artifactId>
+            <version>7.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.8.8</version>

--- a/grid/src/test/resources/testng.xml
+++ b/grid/src/test/resources/testng.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="ios-selenium-tests" parallel="false">
+    <test name="grid regression" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.uiautomation.ios.grid.*"/>
+        </packages>
+
+    </test>
+</suite>

--- a/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/RenderedWebElementTest.java
+++ b/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/RenderedWebElementTest.java
@@ -15,15 +15,13 @@ limitations under the License.
  */
 package org.uiautomation.ios.selenium;
 
-import org.openqa.selenium.*;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.*;
-import static org.openqa.selenium.TestWaiter.waitFor;
+import static org.testng.Assert.assertEquals;
 
 public class RenderedWebElementTest extends BaseSeleniumTest {
 
@@ -34,12 +32,12 @@ public class RenderedWebElementTest extends BaseSeleniumTest {
     WebElement element = driver.findElement(By.id("green-parent"));
     String backgroundColour = element.getCssValue("background-color");
 
-    assertEquals("rgba(0, 128, 0, 1)", backgroundColour);
+    assertEquals(backgroundColour,"rgba(0, 128, 0, 1)");
 
     element = driver.findElement(By.id("red-item"));
     backgroundColour = element.getCssValue("background-color");
 
-    assertEquals("rgba(255, 0, 0, 1)", backgroundColour);
+    assertEquals(backgroundColour,"rgba(255, 0, 0, 1)");
   }
 
   @Test
@@ -48,11 +46,11 @@ public class RenderedWebElementTest extends BaseSeleniumTest {
 
     WebElement element = driver.findElement(By.id("namedColor"));
     String backgroundColour = element.getCssValue("background-color");
-    assertEquals("rgba(0, 128, 0, 1)", backgroundColour);
+    assertEquals(backgroundColour,"rgba(0, 128, 0, 1)");
 
     element = driver.findElement(By.id("rgb"));
     backgroundColour = element.getCssValue("background-color");
-    assertEquals("rgba(0, 128, 0, 1)", backgroundColour);
+    assertEquals(backgroundColour,"rgba(0, 128, 0, 1)");
 
   }
 
@@ -73,7 +71,7 @@ public class RenderedWebElementTest extends BaseSeleniumTest {
     WebElement element = driver.findElement(By.id("green-item"));
     String height = element.getCssValue("height");
 
-    assertEquals("30px", height);
+    assertEquals(height, "30px");
   }
 
   @Test
@@ -83,7 +81,7 @@ public class RenderedWebElementTest extends BaseSeleniumTest {
     WebElement element = driver.findElement(By.tagName("a"));
     String height = element.getCssValue("text-decoration");
 
-    assertEquals("underline", height);
+    assertEquals(height, "underline");
   }
 
   private boolean fuzzyPositionMatching(int expectedX, int expectedY, String locationTouple) {

--- a/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchFlickTest.java
+++ b/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchFlickTest.java
@@ -22,12 +22,11 @@ import org.openqa.selenium.NeedsFreshDriver;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Action;
-import org.openqa.selenium.interactions.touch.FlickAction;
 import org.openqa.selenium.interactions.touch.TouchActions;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.selenium.BaseSeleniumTest;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests the basic flick operations on touch enabled devices.
@@ -70,7 +69,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
 
     int newX = link.getLocation().x;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected x < " + originalX + ", but got x = " + newX, newX < originalX);
+    assertTrue(newX < originalX, "Expected x < " + originalX + ", but got x = " + newX);
   }
 
   @NeedsFreshDriver
@@ -88,7 +87,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newX = link.getLocation().x;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected x < " + originalX + ", but got x = " + newX, newX < originalX);
+    assertTrue(newX < originalX, "Expected x < " + originalX + ", but got x = " + newX);
   }
 
   @NeedsFreshDriver
@@ -105,7 +104,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newX = link.getLocation().x;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected x < " + originalX + ", but got x = " + newX, newX < originalX);
+    assertTrue(newX < originalX, "Expected x < " + originalX + ", but got x = " + newX);
   }
 
   @NeedsFreshDriver
@@ -121,7 +120,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newX = link.getLocation().x;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected x < " + originalX + ", but got x = " + newX, newX < originalX);
+    assertTrue(newX < originalX, "Expected x < " + originalX + ", but got x = " + newX);
   }
 
   @NeedsFreshDriver
@@ -139,7 +138,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newY = link.getLocation().y;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected y < " + originalY + ", but got y = " + newY, newY < originalY);
+    assertTrue(newY < originalY, "Expected y < " + originalY + ", but got y = " + newY);
   }
 
   @NeedsFreshDriver
@@ -157,7 +156,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newY = link.getLocation().y;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected y < " + originalY + ", but got y = " + newY, newY < originalY);
+    assertTrue(newY < originalY, "Expected y < " + originalY + ", but got y = " + newY);
   }
 
   @NeedsFreshDriver
@@ -174,7 +173,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     int newY = link.getLocation().y;
 
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected y < " + originalY + ", but got y = " + newY, newY < originalY);
+    assertTrue(newY < originalY, "Expected y < " + originalY + ", but got y = " + newY);
   }
 
   @NeedsFreshDriver
@@ -190,7 +189,7 @@ public class TouchFlickTest extends BaseSeleniumTest {
     flick.perform();
     int newY = link.getLocation().y;
     // After flicking, the element should now be visible on the screen.
-    assertTrue("Expected y < " + originalY + ", but got y = " + newY, newY < originalY);
+    assertTrue(newY < originalY, "Expected y < " + originalY + ", but got y = " + newY);
   }
 
 }

--- a/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchScrollTest.java
+++ b/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchScrollTest.java
@@ -26,7 +26,7 @@ import org.openqa.selenium.interactions.touch.TouchActions;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.selenium.BaseSeleniumTest;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests the basic scroll operations on touch enabled devices..
@@ -46,7 +46,7 @@ public class TouchScrollTest extends BaseSeleniumTest {
     int y = link.getLocation().y;
     // The element is located at the right of the page,
     // so it is not initially visible on the screen.
-    assertTrue("Expected y > 4200, but got y = " + y, y > 4200);
+    assertTrue(y > 4200, "Expected y > 4200, but got y = " + y);
 
     WebElement toScroll = driver.findElement(By.id("imagestart"));
     Action scroll = getBuilder(driver).scroll(toScroll, 0, -800).build();
@@ -54,7 +54,7 @@ public class TouchScrollTest extends BaseSeleniumTest {
 
     y = link.getLocation().y;
     // After scrolling, the location of the element should change accordingly.
-    assertTrue("Expected y < 3500, but got y = " + y, y < 3500);
+    assertTrue(y < 3500,"Expected y < 3500, but got y = " + y);
   }
 
   @NeedsFreshDriver
@@ -66,7 +66,7 @@ public class TouchScrollTest extends BaseSeleniumTest {
     int x = link.getLocation().x;
     // The element is located at the right of the page,
     // so it is not initially visible on the screen.
-    assertTrue("Expected x > 1500, but got x = " + x, x > 1500);
+    assertTrue(x > 1500, "Expected x > 1500, but got x = " + x);
 
     WebElement toScroll = driver.findElement(By.id("imagestart"));
     Action scroll = getBuilder(driver).scroll(toScroll, -100, 0).build();
@@ -74,7 +74,7 @@ public class TouchScrollTest extends BaseSeleniumTest {
 
     x = link.getLocation().x;
     // After scrolling, the location of the element should change accordingly.
-    assertTrue("Expected x < 1500, but got x = " + x, x < 1500);
+    assertTrue(x < 1500, "Expected x < 1500, but got x = " + x);
   }
 
   @NeedsFreshDriver
@@ -105,14 +105,14 @@ public class TouchScrollTest extends BaseSeleniumTest {
     int x = link.getLocation().x;
     // The element is located at the right of the page,
     // so it is not initially visible on the screen.
-    assertTrue("Expected x > 1500, but got x = " + x, x > 1500);
+    assertTrue(x > 1500, "Expected x > 1500, but got x = " + x);
 
     Action scrollDown = getBuilder(driver).scroll(400, 0).build();
     scrollDown.perform();
 
     x = link.getLocation().y;
     // After scrolling, the location of the element should change accordingly.
-    assertTrue("Expected x < 1500, but got x = " + x, x < 1500);
+    assertTrue(x < 1500, "Expected x < 1500, but got x = " + x);
   }
 
 }

--- a/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchSingleTapTest.java
+++ b/ios-selenium-tests/src/test/java/org/uiautomation/ios/selenium/interactions/touch/TouchSingleTapTest.java
@@ -22,7 +22,7 @@ import org.openqa.selenium.interactions.touch.TouchActions;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.selenium.BaseSeleniumTest;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 import static org.openqa.selenium.TestWaiter.waitFor;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testngVersion>6.8.5</testngVersion>
+        <testngVersion>6.8.8</testngVersion>
         <seleniumVersion>2.42.2</seleniumVersion>
     </properties>
 </project>

--- a/server/src/test/java/org/uiautomation/ios/e2e/abnormalSessionStop/CrashDetectedTest.java
+++ b/server/src/test/java/org/uiautomation/ios/e2e/abnormalSessionStop/CrashDetectedTest.java
@@ -35,9 +35,9 @@ import org.uiautomation.ios.utils.ClassicCommands;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.junit.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 
 public class CrashDetectedTest {
@@ -168,7 +168,7 @@ public class CrashDetectedTest {
 //          e.getMessage().contains("It appears like the Simulator process has crashed"));
       // ios 7 : Fail: The target application appears to have died
     }
-    assertTrue("Simulator crash detected.", crashExceptionThrown);
+    assertTrue( crashExceptionThrown ,"Simulator crash detected.");
   }
 
   @Test
@@ -202,7 +202,7 @@ public class CrashDetectedTest {
 //      Assert.assertTrue("Crash error contains Instruments as likely cause of problem. " + e.getMessage(), e.getMessage().contains("Instruments"));
       // IOS7  :Stopped: Script was stopped by the user
     }
-    assertTrue("Instruments crash detected.", crashExceptionThrown);
+    assertTrue( crashExceptionThrown, "Instruments crash detected.");
   }
 
   @Test
@@ -232,7 +232,7 @@ public class CrashDetectedTest {
 
       JSONObject json = tree.logElementTree(null, false);
 
-      assertNotNull("We can get the page source for a large tableview", json);
+      assertNotNull( json, "We can get the page source for a large tableview");
     } catch (Exception e) {
       fail("Exception caught while performing logElementTree on page with large TreeView. App crashed");
     }

--- a/server/src/test/java/org/uiautomation/ios/e2e/config/AppCapabilityTest.java
+++ b/server/src/test/java/org/uiautomation/ios/e2e/config/AppCapabilityTest.java
@@ -14,11 +14,11 @@
 
 package org.uiautomation.ios.e2e.config;
 
-import junit.framework.Assert;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.BaseIOSDriverTest;
 import org.uiautomation.ios.IOSCapabilities;

--- a/server/src/test/java/org/uiautomation/ios/e2e/config/AutAsUrlTest.java
+++ b/server/src/test/java/org/uiautomation/ios/e2e/config/AutAsUrlTest.java
@@ -14,10 +14,10 @@
 
 package org.uiautomation.ios.e2e.config;
 
-import junit.framework.Assert;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.BaseIOSDriverTest;
 import org.uiautomation.ios.SampleApps;

--- a/server/src/test/java/org/uiautomation/ios/e2e/config/ServerLoadsDefaultsSettingsTest.java
+++ b/server/src/test/java/org/uiautomation/ios/e2e/config/ServerLoadsDefaultsSettingsTest.java
@@ -1,7 +1,7 @@
 package org.uiautomation.ios.e2e.config;
 
-import junit.framework.Assert;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/server/src/test/java/org/uiautomation/ios/server/utils/CoordinateUtilsTest.java
+++ b/server/src/test/java/org/uiautomation/ios/server/utils/CoordinateUtilsTest.java
@@ -16,9 +16,9 @@ package org.uiautomation.ios.server.utils;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
-import junit.framework.Assert;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.remote.Response;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.utils.CoordinateUtils;
 
@@ -44,6 +44,6 @@ public class CoordinateUtilsTest {
     Point expectedPoint = new Point(105, 210);
     Point actualPoint = CoordinateUtils.getCenterPointFromResponse(response);
 
-    Assert.assertEquals("Point should be center of response rectangle", expectedPoint, actualPoint);
+    Assert.assertEquals( expectedPoint, actualPoint,"Point should be center of response rectangle");
   }
 }

--- a/server/src/test/java/org/uiautomation/ios/server/utils/ZipUtilsTest.java
+++ b/server/src/test/java/org/uiautomation/ios/server/utils/ZipUtilsTest.java
@@ -18,8 +18,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import junit.framework.Assert;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.SampleApps;
 import org.uiautomation.ios.utils.ZipUtils;
@@ -30,7 +30,7 @@ public final class ZipUtilsTest {
   public void canExtractAppFromURL() throws IOException {
     URL url = SampleApps.getUICatalogZipURL();
     File appFile = ZipUtils.extractAppFromURL(url);
-    Assert.assertTrue(appFile.getAbsolutePath(), appFile.getName().endsWith("UICatalog.app"));
+    Assert.assertTrue(appFile.getName().endsWith("UICatalog.app"),appFile.getAbsolutePath());
     Assert.assertTrue(new File(appFile, "Info.plist").exists());
   }
 }


### PR DESCRIPTION
- Fixed enforcer plugin failure due to TestNG mismatch
  versions.
- Bumping TestNG dependency to 6.8.8 triggered JUnit
  assert class not found. So fixed all unit tests to use
  TestNG asserts.
- Fixed the build failure for the module ios-grid
  due to missing testng xml file.
