### PR TITLE
Format $maven.build.timestamp so it can be applied to files on WINDOWS

### DIFF
--- a/grid/pom.xml
+++ b/grid/pom.xml
@@ -10,6 +10,9 @@
     </parent>
     <artifactId>ios-grid</artifactId>
 
+    <properties>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmssZ</maven.build.timestamp.format> 
+    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
With this simple change ios-grid can be built on Windows via mvn package -DskipTests'

Otherwise the character : between the default timestamp, which includes the formatting HH:mm::ss, causes a failure. It is not a valid character for file names on Windows.
