### PR TITLE
Fixed Accessibility error and multiple instances error during instruments launch

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
@@ -14,6 +14,20 @@
 
 package org.uiautomation.ios.instruments;
 
+import static org.uiautomation.ios.instruments.commandExecutor.CommunicationMode.CURL;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.Response;
 import org.uiautomation.ios.Device;
@@ -30,14 +44,6 @@ import org.uiautomation.ios.utils.AppleMagicString;
 import org.uiautomation.ios.utils.ClassicCommands;
 import org.uiautomation.ios.utils.Command;
 import org.uiautomation.ios.utils.CommandOutputListener;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
-
-import static org.uiautomation.ios.instruments.commandExecutor.CommunicationMode.CURL;
 
 public class InstrumentsCommandLine implements Instruments {
 
@@ -96,6 +102,9 @@ public class InstrumentsCommandLine implements Instruments {
   public void start(long timeout) throws InstrumentsFailedToStartException {
     boolean success = false;
     try {
+
+      // Remove stale iphonesimulator launchd instances
+      removeStaleSimulatorLaunchds();
       instruments.start();
 
       if (version.getMajor() >= 6 && caps.getReuseContentAndSettings()) {
@@ -275,5 +284,90 @@ public class InstrumentsCommandLine implements Instruments {
     return output;
   }
 
+  /**
+   * Removes stale iphonesimulator launchds hanging in the system
+   */
+  public void removeStaleSimulatorLaunchds() {
+
+    // The instruments crashes sometimes by throwing the following error in the logs
+    // The below logs were taken from Xcode5.1.1
+    // sim[2430:303] Multiple instances of launchd_sim detected, using com.apple.iphonesimulator.launchd.3bd855a 
+    // instead of com.apple.iphonesimulator.launchd.59ef76ee.
+    List<String> launchctlCmd = Arrays.asList("launchctl", "list");
+    Command cmd = new Command(launchctlCmd, false);
+    SimulatorLaunchd simLaunchd = new SimulatorLaunchd();
+    cmd.registerListener(simLaunchd);
+    cmd.executeAndWait(true);
+
+    // Retrieve the stale iphonesimulator launch IDs
+    Set<String> simIDs = simLaunchd.getLaunchdIDs();
+    if (simIDs.size() > 0) {
+      if (log.isLoggable(Level.FINE)) {
+        log.log(Level.FINE, "Removing stale iphonesimulator launchds: " + simIDs);
+      }
+      String iphoneSimulatorPrefix = "com.apple.iphonesimulator.launchd.";
+      for (String id : simIDs) {
+        launchctlCmd = Arrays.asList("launchctl", "remove", iphoneSimulatorPrefix + id);
+        cmd = new Command(launchctlCmd, false);
+        cmd.executeAndWait(true);
+      }
+    }
+  }
+
+
+  /**
+   * Captures stale iphonesimulator launchd IDs. The command listener returns the 
+   * launchd IDs of stale iphonesimulators. This emulates the behaviour of the
+   * command 'launchctl list | grep com.apple.iphonesimulator'.
+   */
+  private static class SimulatorLaunchd implements CommandOutputListener {
+
+    // Pattern to search launchctl for com.apple.iphonesimulator.launchd.<some_id>
+    private Pattern pattern = null;
+
+    // Set holding the simulator launchd IDs
+    private Set<String> launchdIDs = new HashSet<String>();
+
+    // Logger instance
+    private static final Logger logger = Logger.getLogger(SimulatorLaunchd.class.getName());
+
+    SimulatorLaunchd() {
+
+      // Captures stale iphonesimulators launchds i.e.,
+      // [123 - com.apple.iphonesimulator.launchd.6d6b02fa] represents a live iphonesimulator launchd
+      // [- 0 com.apple.iphonesimulator.launchd.6d6b02fa] represents a stale iphonesimulator launchd
+      pattern = Pattern.compile("(-)\\s+(-*\\d+)\\s+com.apple.iphonesimulator.launchd.(\\w+)");
+      launchdIDs = new HashSet<String>();
+    }
+
+    @Override
+    public void stdout(String log) {
+      Matcher matcher = pattern.matcher(log);
+      if (matcher.matches()) {
+        if (!"0".equals(matcher.group(2))) {
+          logger.warning("invalid exit code for iphonesimulator launchd " + matcher.group(0));
+        }
+        launchdIDs.add(matcher.group(3));
+      }
+    }
+
+    @Override
+    public void stderr(String log) {
+      Matcher matcher = pattern.matcher(log);
+      if (matcher.matches()) {
+        logger.warning("CommandOutputListener receiving logs in stderr, 'com.apple.iphonesimulator.launchd' will skip cleaning: " + matcher.group(0));
+      }
+    }
+
+    /**
+     * Returns a {@link Set} of stale iphonesimulator IDs
+     * 
+     * @return Set of stale iphonesimulator IDs
+     */
+    public Set<String> getLaunchdIDs() {
+      return launchdIDs;
+    }
+
+  }
 
 }

--- a/server/src/main/java/org/uiautomation/ios/setup/IOSSimulatorManager.java
+++ b/server/src/main/java/org/uiautomation/ios/setup/IOSSimulatorManager.java
@@ -96,6 +96,9 @@ public class IOSSimulatorManager implements IOSDeviceManager {
     simulatorSettings.setL10N(locale, language);
     simulatorSettings.setKeyboardOptions();
     simulatorSettings.setLocationPreference(/*whitelist*/true, bundleId);
+    
+    // Setting the Accessibility Preferences
+    simulatorSettings.setAccessibilityOptions();
   }
 
   @Override

--- a/server/src/main/java/org/uiautomation/ios/utils/SimulatorSettings.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/SimulatorSettings.java
@@ -106,6 +106,35 @@ public class SimulatorSettings {
     }
   }
 
+  /**
+   * Set the Accessibility preferences. Overrides the values in 'com.apple.Accessibility.plist' file.
+   */
+  public void setAccessibilityOptions() {
+    
+    // Not enabling ApplicationAccessibility may cause intruments to fail with the error 
+    // ScriptAgent[1170:2f07] Failed to enable accessiblity, kAXErrorServerNotFound
+    // The above error is more prominent in Xcode5.1.1 when tested under OSX 10.9.5
+    // Setting ApplicationAccessibilityEnabled for Xcode6.0
+    File folder = new File(contentAndSettingsFolder + "/Library/Preferences/");
+    File preferenceFile = new File(folder, "com.apple.Accessibility.plist");
+    try {
+      JSONObject preferences = new JSONObject();
+      if (instrumentsVersion.getMajor() < 6) {
+        
+        // ex: <key>ApplicationAccessibilityEnabled</key><true/>
+        preferences.put("ApplicationAccessibilityEnabled", true);
+      } else {
+        
+        // Xcode6.0 has integer datatype for ApplicationAccessibilityEnabled
+        // ex: <key>ApplicationAccessibilityEnabled</key><integer>1</integer>
+        preferences.put("ApplicationAccessibilityEnabled", 1);
+      }
+      writeOnDisk(preferences, preferenceFile);
+    } catch (Exception e) {
+      throw new WebDriverException("cannot set options in " + preferenceFile.getAbsolutePath(), e);
+    }
+  }
+
   public void setMobileSafariOptions() {
     File preferenceFile = getMobileSafariPreferencesFile();
     try {


### PR DESCRIPTION
Fixed SimulatorManager and SimulatorSettings to add 'com.apple.Accessibility.plist' file for enabling 'ApplicationAccessibilityEnabled' for applications. This seems to be the cause for the error logs of instruments
'ScriptAgent[1170:2f07] Failed to enable accessiblity, kAXErrorServerNotFound'.

Fixed 'InstrumentsCommandLine' to remove stale instances of iphonesimulator, There was this particular log in instruments while running in Xcode5.1.1.
'sim[2430:303] Multiple instances of launchd_sim detected, using com.apple.iphonesimulator.launchd.3bd855a instead of com.apple.iphonesimulator.launchd.59ef76ee.'
Due to this the instruments never seemed to start at all. I manually removed all the stale iphonesimulator launchd and tried to start which was successful. I have altered the code of InstrumentsCommandLine to fetch the stale iphonesimulators launchd and remove them before starting.
