### PR TITLE
Fix for missing CFBundelIcons

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/application/APPIOSApplication.java
+++ b/server/src/main/java/org/uiautomation/ios/application/APPIOSApplication.java
@@ -228,10 +228,11 @@ public class APPIOSApplication {
   }
 
   private String getFirstIconFile(String bundleIcons) {
-    if (!metadata.has(bundleIcons)) {
-      return "";
-    }
-    try {
+      try {
+        if (!metadata.has(bundleIcons) || ((HashMap) metadata.get(bundleIcons)).size() == 0) {
+            return "";
+        }
+
       HashMap icons = (HashMap) metadata.get(bundleIcons);
       HashMap primaryIcon = (HashMap) icons.get("CFBundlePrimaryIcon");
       ArrayList iconFiles = (ArrayList) primaryIcon.get("CFBundleIconFiles");


### PR DESCRIPTION
Some apps may be using xcassets instead of bundle icons. Because of that entry in plist for CFBundleIcons may be empty. This is causing exception when registering app on server.
