### PR TITLE
Fix for cached large data chunks

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/instruments/commandExecutor/CURLIAutomationCommandExecutor.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/commandExecutor/CURLIAutomationCommandExecutor.java
@@ -130,6 +130,7 @@ public class CURLIAutomationCommandExecutor extends BaseUIAutomationCommandExecu
         }else if (writer.toString().endsWith(FINAL_PART_IDENTIFIER)){
             sessionUUID = writer.toString().substring(0, UUID_LENGTH);
             json =  ((String)jsonMap.get(sessionUUID)).concat(writer.toString().substring(UUID_LENGTH, writer.toString().length() - FINAL_PART_IDENTIFIER.length()));
+            jsonMap.remove(sessionUUID);
         }else{
             json = writer.toString();
         }


### PR DESCRIPTION
When large data payloads are chunked and re-combined on the server
side, the cahce is not cleared after the concatenation occurs. This
fix clears the cache so that after the final part has been concatenated
there will be no String lingering the next time a large data is
chunked and concatenated.
