### PR TITLE
ios-logging.properties installs a FileHandler on the root logger which o...

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/IOSServerConfiguration.java
+++ b/server/src/main/java/org/uiautomation/ios/IOSServerConfiguration.java
@@ -113,6 +113,12 @@ public class IOSServerConfiguration {
   @Parameter(description = "supported real device uuid to whitelist", names = "-uuid")
   private List<String> uuidWhitelist = new ArrayList<String>();
 
+  @Parameter(
+      required = false, arity = 1,
+      names = "-skipLoggerConfiguration",
+      description = "if specified allows user not to load a default logger")
+  private boolean skipLoggerConfiguration = false;
+
   public String getRegistrationURL() {
     return registrationURL;
   }
@@ -215,5 +221,13 @@ public class IOSServerConfiguration {
 
   public void setMaxIdleTimeBetween2CommandsInSeconds(int maxIdleTimeBetween2CommandsInSeconds) {
     this.maxIdleTimeBetween2CommandsInSeconds = maxIdleTimeBetween2CommandsInSeconds;
+  }
+
+  public boolean getSkipLoggerConfiguration() {
+    return skipLoggerConfiguration;
+  }
+
+  public void setSkipLoggerConfiguration(boolean skipLoggerConfiguration) {
+    this.skipLoggerConfiguration = skipLoggerConfiguration;
   }
 }

--- a/server/src/main/java/org/uiautomation/ios/IOSServerManager.java
+++ b/server/src/main/java/org/uiautomation/ios/IOSServerManager.java
@@ -76,6 +76,9 @@ public class IOSServerManager {
     this.options = options;
     TIME_OUT_FOR_SESSION = options.getSessionTimeoutMillis();
 
+    //check if skipLoggingConfiguration is set to true
+    boolean skipLogging = options.getSkipLoggerConfiguration();
+
     // setup logging
     String loggingConfigFile = System.getProperty("java.util.logging.config.file");
     if (loggingConfigFile != null) {
@@ -85,8 +88,9 @@ public class IOSServerManager {
         loggingConfigFile = null; // to revert to builtin one
       }
     }
-    if (loggingConfigFile == null) {
+    if (loggingConfigFile == null && !skipLogging) {
       // do not use builtin ios-logging.properties if -Djava.util.logging.config.file set
+      // or if skipLoggingConfiguration is set to true
       try {
         LogManager.getLogManager().readConfiguration(
             IOSServerManager.class.getResourceAsStream("/ios-logging.properties"));


### PR DESCRIPTION
...utputs ALL events to ios-driver.log #322
- Adding a configuration to allow the user to skip ios-driver default logging configuration
