### PR TITLE
Don't do stale element test on creating JSON response after a scroll request

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/command/uiautomation/ElementScrollNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/command/uiautomation/ElementScrollNHandler.java
@@ -27,33 +27,33 @@ public class ElementScrollNHandler extends UIAScriptHandler {
   private static final JSTemplate scrollUpTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollUp();" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')");
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)");
   private static final JSTemplate scrollDownTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollDown();" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')");
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)");
   private static final JSTemplate scrollLeftTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollLeft();" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')");
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)");
   private static final JSTemplate scrollRightTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollRight();" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')");
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)");
   private static final JSTemplate scrollToNameTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollToElementWithName('%:name$s');" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')",
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)",
       "name");
   private static final JSTemplate scrollToPredicateTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollToElementWithPredicate(\"%:predicateString$s\");" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')",
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)",
       "predicateString");
   private static final JSTemplate scrollToVisibleTemplate = buildJSTemplate(
       "var element = UIAutomation.cache.get(%:reference$s);" +
       "element.scrollToVisible();" +
-      "UIAutomation.createJSONResponse('%:sessionId$s',0,'')");
+      "UIAutomation.createJSONResponse('%:sessionId$s',0,'', true)");
 
   private static JSTemplate buildJSTemplate(String template, String... extraArgs) {
     String[] args = {"sessionId", "reference"};

--- a/server/src/main/resources/instruments-js/UIAutomation.js
+++ b/server/src/main/resources/instruments-js/UIAutomation.js
@@ -32,9 +32,11 @@ var UIAutomation = {
      * @param {string} sessionId the session currently controlling instruments.
      * @param {number} status the response status. 0 for ok.
      * @param {Object} value the response value
+     * @param {bool} opt_skipStale An optional flag indicating whether the cache should skip its check for stale
+     *               elements when it's consulted in preparing the response.
      * @return {string} the response value, stringified.
      */
-    createJSONResponse: function (sessionId, status, value) {
+    createJSONResponse: function (sessionId, status, value, opt_skipStale) {
         var result = {};
         result.sessionId = sessionId;
         result.status = status;
@@ -70,7 +72,11 @@ var UIAutomation = {
             } else if (value && value.type) {
                 // check if the element is in an alert to throw the unexpected alert exception if needed
                 try {
-                    this.cache.get(value.reference());
+                    var skipStale = false;
+                    if (opt_skipStale === true) {
+                        skipStale = true;
+                    }
+                    this.cache.get(value.reference(), !skipStale);
                     res.ELEMENT = "" + value.reference();
                     res.type = value.type();
                 } catch (err) {


### PR DESCRIPTION
The check can scroll views, which is interfering with legitimate attempts to scroll the UI in ios-driver.
