### PR TITLE
Distinguish between Instruments crashing and the AUT crashing

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/ServerSideSession.java
+++ b/server/src/main/java/org/uiautomation/ios/ServerSideSession.java
@@ -29,6 +29,7 @@ import org.uiautomation.ios.command.configuration.DriverConfigurationStore;
 import org.uiautomation.ios.communication.WebDriverLikeCommand;
 import org.uiautomation.ios.communication.device.DeviceVariation;
 import org.uiautomation.ios.drivers.IOSDualDriver;
+import org.uiautomation.ios.instruments.ApplicationCrashedOnStartException;
 import org.uiautomation.ios.instruments.InstrumentsFailedToStartException;
 import org.uiautomation.ios.logging.IOSLogManager;
 import org.uiautomation.ios.session.monitor.ApplicationCrashMonitor;
@@ -301,7 +302,7 @@ public class ServerSideSession extends Session {
     return driver;
   }
 
-  public void start(long timeOut) throws InstrumentsFailedToStartException {
+  public void start(long timeOut) throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException {
     driver.start(timeOut);
 
     startedTime = System.currentTimeMillis();

--- a/server/src/main/java/org/uiautomation/ios/command/uiautomation/NewSessionNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/command/uiautomation/NewSessionNHandler.java
@@ -25,6 +25,7 @@ import org.uiautomation.ios.SessionNotInitializedException;
 import org.uiautomation.ios.command.BaseNativeCommandHandler;
 import org.uiautomation.ios.communication.WebDriverLikeRequest;
 import org.uiautomation.ios.drivers.RecoverableCrashException;
+import org.uiautomation.ios.instruments.ApplicationCrashedOnStartException;
 import org.uiautomation.ios.instruments.InstrumentsFailedToStartException;
 import org.uiautomation.ios.utils.ServerIsShutingDownException;
 
@@ -101,10 +102,13 @@ public final class NewSessionNHandler extends BaseNativeCommandHandler {
       throw new SessionNotCreatedException("The server cannot run " + cap + " at the moment." + e.getMessage());
     } catch (InstrumentsFailedToStartException|RecoverableCrashException e) {
       log.warning("Instruments failed to start in the allocated time ( " + timeOut + "sec):" + e
-          .getMessage());
+              .getMessage());
       if (session != null) {
         session.stop();
       }
+    } catch (ApplicationCrashedOnStartException e) {
+      log.warning("Application crashed while instruments was launching:" + e);
+      session.stop(ServerSideSession.StopCause.crash);
     } catch (Exception e) {
       log.warning("Error starting the session." + e.getMessage());
       if (session != null) {

--- a/server/src/main/java/org/uiautomation/ios/command/uiautomation/NewSessionNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/command/uiautomation/NewSessionNHandler.java
@@ -84,7 +84,7 @@ public final class NewSessionNHandler extends BaseNativeCommandHandler {
   }
 
   private ServerSideSession safeStart(long timeOut, IOSCapabilities cap)
-      throws InstrumentsFailedToStartException {
+      throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException {
     ServerSideSession session = null;
     try {
       // init session
@@ -109,6 +109,7 @@ public final class NewSessionNHandler extends BaseNativeCommandHandler {
     } catch (ApplicationCrashedOnStartException e) {
       log.warning("Application crashed while instruments was launching:" + e);
       session.stop(ServerSideSession.StopCause.crash);
+      throw e;
     } catch (Exception e) {
       log.warning("Error starting the session." + e.getMessage());
       if (session != null) {

--- a/server/src/main/java/org/uiautomation/ios/drivers/IOSDualDriver.java
+++ b/server/src/main/java/org/uiautomation/ios/drivers/IOSDualDriver.java
@@ -22,10 +22,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.UIAModels.configuration.WorkingMode;
-import org.uiautomation.ios.instruments.Instruments;
-import org.uiautomation.ios.instruments.InstrumentsFactory;
-import org.uiautomation.ios.instruments.InstrumentsFailedToStartException;
-import org.uiautomation.ios.instruments.NoInstrumentsImplementationAvailable;
+import org.uiautomation.ios.instruments.*;
 import org.uiautomation.ios.setup.IOSDeviceManager;
 import org.uiautomation.ios.setup.IOSDeviceManagerFactory;
 import org.uiautomation.ios.setup.IOSSafariSimulatorManager;
@@ -120,7 +117,7 @@ public class IOSDualDriver {
     }
   }
 
-  public void start(long timeOut) throws InstrumentsFailedToStartException {
+  public void start(long timeOut) throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException {
     deviceManager.setup();
 
     try {
@@ -128,7 +125,7 @@ public class IOSDualDriver {
       if (deviceManager instanceof IOSSafariSimulatorManager) {
         ((IOSSafariSimulatorManager) deviceManager).tmpFix();
       }
-    } catch (InstrumentsFailedToStartException e) {
+    } catch (InstrumentsFailedToStartException|ApplicationCrashedOnStartException e) {
       deviceManager.teardown();
       throw e;
     }

--- a/server/src/main/java/org/uiautomation/ios/drivers/RemoteIOSNativeDriver.java
+++ b/server/src/main/java/org/uiautomation/ios/drivers/RemoteIOSNativeDriver.java
@@ -16,6 +16,7 @@ package org.uiautomation.ios.drivers;
 
 import org.openqa.selenium.remote.SessionId;
 import org.uiautomation.ios.ServerSideSession;
+import org.uiautomation.ios.instruments.ApplicationCrashedOnStartException;
 import org.uiautomation.ios.instruments.commandExecutor.UIAutomationCommandExecutor;
 import org.uiautomation.ios.instruments.Instruments;
 import org.uiautomation.ios.instruments.TakeScreenshotService;
@@ -41,11 +42,11 @@ public class RemoteIOSNativeDriver extends ServerSideNativeDriver {
     };
   }
 
-  public void start(long timeOut) throws InstrumentsFailedToStartException {
+  public void start(long timeOut) throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException {
     try {
       instruments.start(timeOut);
       Runtime.getRuntime().addShutdownHook(shutdownHook);
-    } catch (InstrumentsFailedToStartException e) {
+    } catch (InstrumentsFailedToStartException|ApplicationCrashedOnStartException e) {
       stop();
       throw e;
     }

--- a/server/src/main/java/org/uiautomation/ios/instruments/ApplicationCrashedOnStartException.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/ApplicationCrashedOnStartException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 eBay Software Foundation and ios-driver committers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.uiautomation.ios.instruments;
+
+public class ApplicationCrashedOnStartException extends Exception {
+    public ApplicationCrashedOnStartException(String message) { super(message); }
+    public ApplicationCrashedOnStartException(String message, InterruptedException cause) { super(message, cause); }
+}

--- a/server/src/main/java/org/uiautomation/ios/instruments/Instruments.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/Instruments.java
@@ -23,7 +23,7 @@ import org.uiautomation.ios.utils.CommandOutputListener;
 
 public interface Instruments {
 
-  void start(long timeOut) throws InstrumentsFailedToStartException;
+  void start(long timeOut) throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException;
   int waitForProcessToDie();
   void stop();
 

--- a/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
@@ -93,7 +93,7 @@ public class InstrumentsCommandLine implements Instruments {
 
 
   @Override
-  public void start(long timeout) throws InstrumentsFailedToStartException {
+  public void start(long timeout) throws InstrumentsFailedToStartException, ApplicationCrashedOnStartException {
     boolean success = false;
     try {
       instruments.start();
@@ -136,8 +136,14 @@ public class InstrumentsCommandLine implements Instruments {
       log.fine("registration request received" + session.getCachedCapabilityResponse());
       if (!success) {
         log.warning("instruments crashed (" + ((System.currentTimeMillis() - waitStartTime) / 1000) + " sec)".toUpperCase());
-        throw new InstrumentsFailedToStartException(
-            "Didn't get the capability back.Most likely, instruments crashed at startup.");
+        instruments.waitFor(-1);
+        if (instruments.getExitStatus() == 0) {
+          //instruments successfully completed, which means the app terminated rather than instruments crashing.
+          throw new ApplicationCrashedOnStartException("Instruments did not start a session because the application crashed.");
+        } else {
+          throw new InstrumentsFailedToStartException(
+                  "Didn't get the capability back.Most likely, instruments crashed at startup.");
+        }
       }
     } catch (InterruptedException e) {
       throw new InstrumentsFailedToStartException("instruments was interrupted while starting.");

--- a/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
+++ b/server/src/main/java/org/uiautomation/ios/instruments/InstrumentsCommandLine.java
@@ -136,8 +136,8 @@ public class InstrumentsCommandLine implements Instruments {
       log.fine("registration request received" + session.getCachedCapabilityResponse());
       if (!success) {
         log.warning("instruments crashed (" + ((System.currentTimeMillis() - waitStartTime) / 1000) + " sec)".toUpperCase());
-        instruments.waitFor(-1);
-        if (instruments.getExitStatus() == 0) {
+        int exitStatus = instruments.waitFor((int)timeout*1000);
+        if (exitStatus == 0) {
           //instruments successfully completed, which means the app terminated rather than instruments crashing.
           throw new ApplicationCrashedOnStartException("Instruments did not start a session because the application crashed.");
         } else {

--- a/server/src/main/java/org/uiautomation/ios/utils/Command.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/Command.java
@@ -223,19 +223,4 @@ public class Command {
     environment.put(key, value);
   }
 
-  /**
-   * Return this command's exit status.
-   * Throws WebDriverException if called before the process has terminated (including if it hasn't even started).
-   */
-  public int getExitStatus() {
-    if (process == null) {
-      throw new WebDriverException("attempt to get exit status before starting a command");
-    }
-    try {
-      return process.exitValue();
-    }
-    catch (IllegalThreadStateException e) {
-      throw new WebDriverException(e);
-    }
-  }
 }

--- a/server/src/main/java/org/uiautomation/ios/utils/Command.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/Command.java
@@ -222,4 +222,20 @@ public class Command {
   public void addEnvironment(String key, String value) {
     environment.put(key, value);
   }
+
+  /**
+   * Return this command's exit status.
+   * Throws WebDriverException if called before the process has terminated (including if it hasn't even started).
+   */
+  public int getExitStatus() {
+    if (process == null) {
+      throw new WebDriverException("attempt to get exit status before starting a command");
+    }
+    try {
+      return process.exitValue();
+    }
+    catch (IllegalThreadStateException e) {
+      throw new WebDriverException(e);
+    }
+  }
 }


### PR DESCRIPTION
If instruments leaves a non-zero return value on failing to start a session, then it died. If the app under test crashes, then Instruments exits without error (I know, I know...). Distinguish these two cases so that test suites can tell when the app is crashing quickly.
