### PR TITLE
Only create WebKitPages for Web inspector responses.

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/wkrdp/message/ApplicationSentListingMessage.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/message/ApplicationSentListingMessage.java
@@ -35,7 +35,10 @@ public class ApplicationSentListingMessage extends BaseIOSWebKitMessage {
 
     for (String key : keys) {
       NSDictionary page = (NSDictionary) list.objectForKey(key);
-      pages.add(new WebkitPage(page));
+      String pageType = page.objectForKey("WIRTypeKey").toString();
+      if (pageType != null && pageType.equals("WIRTypeWeb")) {
+        pages.add(new WebkitPage(page));
+      }
     }
     if (log.isLoggable(Level.FINE))
       log.fine("got: " + this);


### PR DESCRIPTION
The inspector protocol can also send JavaScript responses, which don't have
all the same fields as Web responses. Creating WebKitPage objects to model
them eventually leads to a NPE in accessing those fields.
