### PR TITLE
NoSuchElementException in remote web driver

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/drivers/RemoteIOSWebDriver.java
+++ b/server/src/main/java/org/uiautomation/ios/drivers/RemoteIOSWebDriver.java
@@ -188,10 +188,14 @@ public class RemoteIOSWebDriver {
         protocol.connect(bundleId);
         sync.waitForSimToSendPages();
         log.fine("bundleId=" + bundleId);
-        switchTo(Collections.max(getPages()));
-        if (getPages().size() > 1) {
-          log.warning("Application started, but already have " + getPages().size()
-                      + " webviews. Connecting to the one with highest page id.");
+        if (getPages() != null && getPages().size() > 0) {
+          switchTo(Collections.max(getPages()));
+          if (getPages().size() > 1) {
+            log.warning("Application started, but already have " + getPages().size()
+                + " webviews. Connecting to the one with highest page id.");
+          }
+        } else {
+            log.warning("Application started, but doesn't have any page.");
         }
         return;
       }


### PR DESCRIPTION
waitForSimToSendPages times out after 5 sec. It is possible that no pages are returned by then. We are occasionally hitting NoSuchElementException because of this. Let's put an if check.
