### PR TITLE
Using RuleBasedCollator for string matching in xpaths

### DIFF
--- a/server/src/test/java/org/uiautomation/ios/server/XpathTreeFinderTest.java
+++ b/server/src/test/java/org/uiautomation/ios/server/XpathTreeFinderTest.java
@@ -55,8 +55,8 @@ public class XpathTreeFinderTest {
     tree = new JSONObject(uiCatalog1).getJSONObject("tree");
     treeIntl = new JSONObject(intlMountainZH);
 
-    parserIntl = new XPath2Engine(new JSONToXMLConverter(treeIntl).asXML());
-    parser = new XPath2Engine(new JSONToXMLConverter(tree).asXML());
+    parserIntl = new XPath2Engine(new JSONToXMLConverter(treeIntl).asXML(), null);
+    parser = new XPath2Engine(new JSONToXMLConverter(tree).asXML(), null);
 
   }
 


### PR DESCRIPTION
Using RuleBasedCollator for string comparisons in xpath instead of plain and simple unicode point matcher. For certain locales (eg Thai), there can be multiple ways to represent the same character. So instead of doing exact match, we need to do canonical equivalence.
