### PR TITLE
Avoid NPE in Xcode 5.1.1 where WIRTypeKey is not set in the debug object

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/wkrdp/message/ApplicationSentListingMessage.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/message/ApplicationSentListingMessage.java
@@ -16,6 +16,7 @@ package org.uiautomation.ios.wkrdp.message;
 
 
 import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +36,8 @@ public class ApplicationSentListingMessage extends BaseIOSWebKitMessage {
 
     for (String key : keys) {
       NSDictionary page = (NSDictionary) list.objectForKey(key);
-      String pageType = page.objectForKey("WIRTypeKey").toString();
-      if (pageType != null && pageType.equals("WIRTypeWeb")) {
+      NSObject pageType = page.objectForKey("WIRTypeKey");
+      if (pageType != null && pageType.toString().equals("WIRTypeWeb")) {
         pages.add(new WebkitPage(page));
       }
     }


### PR DESCRIPTION
Comment from @kumaravel-jayakumar that this was causing a NPE on older Xcode.
