### PR TITLE
Fix to identify SDK(s)/Device(s) version with three parts (major.minor.incremental)

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/utils/AppleMagicString.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/AppleMagicString.java
@@ -26,7 +26,8 @@ public class AppleMagicString {
                                        String desiredSDKVersion, InstrumentsVersion instrumentsVersion) {
     // 'iPad Retina (64-bit) - Simulator - iOS 7.1' or 'iPhone 5 (8.0 Simulator)' if Xcode 6 or later is being used
     IOSVersion iosVersion = new IOSVersion(desiredSDKVersion);
-    String version = iosVersion.getMajor() + '.' + iosVersion.getMinor();
+    String version = iosVersion.getMajor() + '.' + iosVersion.getMinor() + (iosVersion.getIncremental() != null ? ("."
+        + iosVersion.getIncremental()) : "");
     String name = getSimulateDeviceValue(device, variation, desiredSDKVersion, instrumentsVersion);
     String specification;
     if (instrumentsVersion.getMajor() < 6) {

--- a/server/src/main/java/org/uiautomation/ios/utils/DeviceUUIDsMap.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/DeviceUUIDsMap.java
@@ -7,14 +7,27 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.openqa.selenium.WebDriverException;
+
 public class DeviceUUIDsMap implements CommandOutputListener {
 
-  private static final Pattern sdkPattern = Pattern.compile("-- iOS (.*) --");
-  private static final Pattern simulatorPattern =
-    Pattern.compile("    (.*) \\((\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\) \\(\\w*\\)");
+  private static final Pattern iOSPattern = Pattern.compile("-- iOS (.*) --");
 
-  private String currentSDK;
+  private static final Pattern simulatorPattern = Pattern
+      .compile("    (.*) \\((\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12})\\) \\(\\w*\\)");
+
+  private static final Pattern iOSToSdkPattern = Pattern
+      .compile("iOS ([\\d\\.]+) \\(([\\d\\.]+) - (\\S+)\\) \\(com.apple.CoreSimulator.SimRuntime.iOS-\\d-\\d\\)");
+
   private Map<String, String> simulatorToUUID = new HashMap<>();
+
+  private Map<String, SdkVersionBuildInfo> iOSToSdkMap = new HashMap<String, SdkVersionBuildInfo>();
+
+  private WebDriverException commandParsingException = null;
+
+  private String iOSUnderScan = null;
+
+  private String commandOutput = null;
 
   public void loadData() {
     List<String> listArgs = new ArrayList<>();
@@ -24,21 +37,65 @@ public class DeviceUUIDsMap implements CommandOutputListener {
     Command listCommand = new Command(listArgs, false);
     listCommand.registerListener(this);
     listCommand.executeAndWait();
+    if (isParsingExceptionEncountered()) {
+      throw commandParsingException;
+    }
   }
 
   @Override
   public void stdout(String log) {
-    Matcher sdkMatcher = sdkPattern.matcher(log);
-    if (sdkMatcher.matches()) {
-      currentSDK = sdkMatcher.group(1);
+    if (isParsingExceptionEncountered()) {
+      return;
     }
+    commandOutput = log;
+    parseCommandOutput();
+  }
 
-    Matcher simulatorMatcher = simulatorPattern.matcher(log);
+  private boolean isParsingExceptionEncountered() {
+    return commandParsingException != null;
+  }
+
+  private void parseCommandOutput() {
+    try {
+      checkForIOSToSDKMatch();
+      setUpIOSUnderScan();
+      checkForDeviceToUUIDMatch();
+    } catch (WebDriverException webDriverException) {
+      commandParsingException = webDriverException;
+    }
+  }
+
+  private void checkForIOSToSDKMatch() {
+    Matcher iOSToSdkMatcher = iOSToSdkPattern.matcher(commandOutput);
+    if (iOSToSdkMatcher.matches()) {
+      if (iOSToSdkMatcher.group(1) == null || iOSToSdkMatcher.group(2) == null) {
+        throw new WebDriverException("Cannot find iOS/SDK version in the command output: "
+            + iOSToSdkMatcher.group(0));
+      }
+      iOSUnderScan = iOSToSdkMatcher.group(1);
+      addToSDKMap(iOSToSdkMatcher.group(2), iOSToSdkMatcher.group(3));
+      iOSUnderScan = null;
+    }
+  }
+
+  private void addToSDKMap(String sdkVersion, String build) {
+    SdkVersionBuildInfo versionBuildInfo = new SdkVersionBuildInfo(sdkVersion, build);
+    iOSToSdkMap.put(iOSUnderScan, versionBuildInfo);
+  }
+
+  private void setUpIOSUnderScan() {
+    Matcher sdkMatcher = iOSPattern.matcher(commandOutput);
+    if (sdkMatcher.matches()) {
+      iOSUnderScan = sdkMatcher.group(1);
+    }
+  }
+
+  private void checkForDeviceToUUIDMatch() {
+    Matcher simulatorMatcher = simulatorPattern.matcher(commandOutput);
     if (simulatorMatcher.matches()) {
       String device = simulatorMatcher.group(1);
       String uuid = simulatorMatcher.group(2);
-
-      simulatorToUUID.put(currentSDK + "," + device, uuid);
+      simulatorToUUID.put(iOSToSdkMap.get(iOSUnderScan).getSdkVersion() + "," + device, uuid);
     }
   }
 
@@ -48,5 +105,33 @@ public class DeviceUUIDsMap implements CommandOutputListener {
 
   public String getUUID(String sdkVersion, String deviceName) {
     return simulatorToUUID.get(sdkVersion + "," + deviceName);
+  }
+
+  /**
+   * DataStructure to hold SDK version and Build number for a particular iOS Version
+   */
+  private static class SdkVersionBuildInfo {
+
+    private final String sdkVersion;
+
+    private final String build;
+
+    SdkVersionBuildInfo(String sdkVersion, String build) {
+      this.sdkVersion = sdkVersion;
+      this.build = build;
+    }
+
+    public String getSdkVersion() {
+      return sdkVersion;
+    }
+
+    public String getBuild() {
+      return build;
+    }
+
+    @Override
+    public String toString() {
+      return "[SDK Version: " + sdkVersion + ", Build: " + build + "]";
+    }
   }
 }


### PR DESCRIPTION
If iOS SDK 7.0 (which is 7.0.3) is installed. The system is not able to find devices (iPhone/iPad) when IOSCapabilities.setSDKVersion("7.0.3") is requested because the devices are listed under version "7.0". Setting IOSCapabilities.setSDKVersion("7.0") complains  that the devices are available for "7.0.3". This pull request fixes that issue.
