### PR TITLE
Don't try to get page source when I don't have a page.

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/command/uiautomation/LogElementTreeNHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/command/uiautomation/LogElementTreeNHandler.java
@@ -180,7 +180,9 @@ public class LogElementTreeNHandler extends UIAScriptHandler {
             log.severe("cannot decorate null webDriver");
             rawHTML = "<inspector is null>";
           } else {
-            rawHTML = inspector.getPageSource();
+            if (inspector.getCurrentPageID() != -1) {
+              rawHTML = inspector.getPageSource();
+            }
           }
           rawHTML = (rawHTML == null ? "<page source is null>" : rawHTML);
           webView.put("source", rawHTML);


### PR DESCRIPTION
ios-driver was crashing with an NPE if it had a web inspector but that inspector didn't represent a loaded page.
