### PR TITLE
Not throwing an exception if we fail to read the provisioning profile

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/application/IPAApplication.java
+++ b/server/src/main/java/org/uiautomation/ios/application/IPAApplication.java
@@ -158,7 +158,8 @@ public class IPAApplication extends APPIOSApplication {
       res.setCapability(IOSCapabilities.PROVISIONNED,info.getDevices());
     } catch (Exception e) {
       log.warning("Cannot extract profile. corrupted ipa ?");
+    } finally {
+      return res;
     }
-    return res;
   }
 }

--- a/server/src/main/java/org/uiautomation/ios/application/IPAApplication.java
+++ b/server/src/main/java/org/uiautomation/ios/application/IPAApplication.java
@@ -156,9 +156,9 @@ public class IPAApplication extends APPIOSApplication {
     try {
       ProvisioningProfileInfo info = ProvisioningService.getProfile(getEmbeddedProfile());
       res.setCapability(IOSCapabilities.PROVISIONNED,info.getDevices());
-      return res;
     } catch (Exception e) {
-      throw new WebDriverException("Cannot extract probile. corrupted ipa ?");
+      log.warning("Cannot extract profile. corrupted ipa ?");
     }
+    return res;
   }
 }


### PR DESCRIPTION
libimobiledevice is unable to extract the provisioning profile from ipas which are not corrupt. So turning an exception to a log.
