### PR TITLE
Decode escaped chars in path when locating test apps.

### DIFF
--- a/server/src/test/java/org/uiautomation/ios/SampleApps.java
+++ b/server/src/test/java/org/uiautomation/ios/SampleApps.java
@@ -15,6 +15,7 @@ package org.uiautomation.ios;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.logging.Logger;
 
@@ -37,10 +38,13 @@ public class SampleApps {
   private static File getFromClassPath(String resource) {
     URL url = SampleApps.class.getResource(resource);
     File res = null;
-    if (url.toExternalForm().startsWith("file:")) {
-      res = new File(url.toExternalForm().replace("file:", ""));
+    try {
+      // Decode escaped chars in path (%20 - space)
+      res = new File(url.toURI().getPath());
     }
-
+    catch (URISyntaxException e) {
+      log.info("Incorrectly formed path to " + url.getPath());
+    }
     if (res == null || !res.exists()) {
       throw new RuntimeException("Cannot load test app from " + url);
     }


### PR DESCRIPTION
`SampleApps.getFromClassPath()` uses `URL.toExternalForm()` to specify the path to test application files.  This returns the path without decoding escape characters such as `%20` as spaces.  Passing this encoded path to `File.exists()` results in the RuntimeException below because the file cannot be found.  Using `URI.getPath()` to decode escaped characters in the path results in the correct behavior from `File.exists()`.

``` Java
FATAL error in RemoteUIAElementTest.beforeClass: java.lang.RuntimeException: Cannot load test app from file:/Users/chris/Documents/University%20of%20Texas/CS%20378/Open%20Source%20Software/ios-driver/server/target/test-classes/sampleApps/UICatalog.app
Apr 22, 2015 11:05:32 AM org.uiautomation.ios.BaseIOSDriverTest beforeClass
SEVERE: java.lang.RuntimeException: Cannot load test app from file:/Users/chris/Documents/University%20of%20Texas/CS%20378/Open%20Source%20Software/ios-driver/server/target/test-classes/sampleApps/UICatalog.app
java.lang.RuntimeException: Cannot load test app from file:/Users/chris/Documents/University%20of%20Texas/CS%20378/Open%20Source%20Software/ios-driver/server/target/test-classes/sampleApps/UICatalog.app
    at org.uiautomation.ios.SampleApps.getFromClassPath(SampleApps.java:52)
    at org.uiautomation.ios.SampleApps.getUICatalogFile(SampleApps.java:66)
    at org.uiautomation.ios.BaseIOSDriverTest.startServer(BaseIOSDriverTest.java:57)
    at org.uiautomation.ios.BaseIOSDriverTest.beforeClass(BaseIOSDriverTest.java:42)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
    at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:564)
    at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:213)
    at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:138)
    at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:175)
    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:107)
    at org.testng.TestRunner.privateRun(TestRunner.java:767)
    at org.testng.TestRunner.run(TestRunner.java:617)
    at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
    at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
    at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
    at org.testng.SuiteRunner.run(SuiteRunner.java:254)
    at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
    at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
    at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
    at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
    at org.testng.TestNG.run(TestNG.java:1057)
    at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:178)
    at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:92)
    at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:96)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
    at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
    at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:113)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```
