### PR TITLE
fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ before_script:
 - sudo chmod -R 666 /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator*.sdk/Applications/MobileSafari.app/Info.plist
 - sudo /usr/sbin/DevToolsSecurity --enable
 - sudo dscl . append /Groups/_developer GroupMembership travis
-- sudo python ./sim_access.py
-- grep -A 10 system.privilege.taskport /etc/authorization
-- sudo mkdir /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/exiledSDKs 
+- export "JAVA_HOME=`/usr/libexec/java_home`"
+- java -version
+- grep -A 10 system.privilege.taskport /System/Library/Security/authorization.plist
+- sudo mkdir /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/exiledSDKs
 - sudo chmod -R a+rw /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/exiledSDKs
 - sudo chmod 666 /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator*.sdk/Applications/MobileSafari.app/Info.plist
 script: mvn test


### PR DESCRIPTION
add `JAVA_HOME` and change path of `authorization` file.

This fix will help the project can run on Travis CI again.

`<testFailureIgnore>true</testFailureIgnore>` in pom.xml file makes Travis CI show the build is `passing` even though the build doesn't pass all of the tests.
