### PR TITLE
IOS8 Physical Device Support

### DIFF
--- a/common/src/main/resources/ios-logging.properties
+++ b/common/src/main/resources/ios-logging.properties
@@ -35,10 +35,10 @@ java.util.logging.ConsoleHandler.formatter = org.uiautomation.ios.LogFormatter
 
 # File Logging
 java.util.logging.FileHandler.level = ALL
-java.util.logging.FileHandler.pattern = ios-driver.log
+java.util.logging.FileHandler.pattern = %h/.ios-driver/ios-driver.log
 java.util.logging.FileHandler.formatter = org.uiautomation.ios.LogFormatter
 
 org.uiautomation.ios.LogstashFileHandler.level = ALL
-org.uiautomation.ios.LogstashFileHandler.pattern = logstash-ios-driver.log
+org.uiautomation.ios.LogstashFileHandler.pattern = %h/.ios-driver/logstash-ios-driver.log
 org.uiautomation.ios.LogstashFileHandler.formatter = org.uiautomation.ios.LogstashFormatter
 org.uiautomation.ios.LogstashFileHandler.append = true

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/WebKitRemoteDebugProtocolFactory.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/WebKitRemoteDebugProtocolFactory.java
@@ -15,6 +15,7 @@
 package org.uiautomation.ios.wkrdp;
 
 import org.uiautomation.ios.RealDevice;
+import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.drivers.RemoteIOSNativeDriver;
 import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.command.configuration.Configuration;
@@ -42,10 +43,10 @@ public class WebKitRemoteDebugProtocolFactory {
         Configuration.off();
       }
       String uuid = ((RealDevice) session.getDevice()).getUuid();
-      return new RealDeviceProtocolImpl(uuid, finders);
+      return new RealDeviceProtocolImpl(uuid, finders, session);
 
     } else {
-      return new SimulatorProtocolImpl(finders);
+      return new SimulatorProtocolImpl(finders, session);
     }
   }
 }

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/internal/DefaultMessageHandler.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/internal/DefaultMessageHandler.java
@@ -15,6 +15,7 @@ package org.uiautomation.ios.wkrdp.internal;
 
 import org.json.JSONObject;
 import org.openqa.selenium.TimeoutException;
+import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.wkrdp.WebInspector;
 import org.uiautomation.ios.wkrdp.ConnectListener;
 import org.uiautomation.ios.wkrdp.MessageHandler;
@@ -42,13 +43,14 @@ public class DefaultMessageHandler implements MessageHandler {
   private boolean stopped;
   private static final Logger log = Logger.getLogger(DefaultMessageHandler.class.getName());
   private List<ResponseFinder> extraFinders = new ArrayList<ResponseFinder>();
-  private final MessageFactory factory = new MessageFactory();
+  private final MessageFactory factory;
   private final
   DefaultWebKitResponseFinder
       defaultFinder =
       new DefaultWebKitResponseFinder(timeoutInMs);
 
-  public DefaultMessageHandler(List<ResponseFinder> finders) {
+  public DefaultMessageHandler(List<ResponseFinder> finders, ServerSideSession session) {
+    factory = new MessageFactory(session);
     this.extraFinders.addAll(finders);
   }
 

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/internal/RealDeviceProtocolImpl.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/internal/RealDeviceProtocolImpl.java
@@ -18,6 +18,7 @@ import org.libimobiledevice.ios.driver.binding.exceptions.SDKException;
 import org.libimobiledevice.ios.driver.binding.services.DeviceService;
 import org.libimobiledevice.ios.driver.binding.services.IOSDevice;
 import org.libimobiledevice.ios.driver.binding.services.WebInspectorService;
+import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.wkrdp.ResponseFinder;
 
 import java.util.List;
@@ -33,8 +34,8 @@ public class RealDeviceProtocolImpl extends WebKitRemoteDebugProtocol {
 
   private final WebInspectorService inspector;
 
-  public RealDeviceProtocolImpl(String uuid, List<ResponseFinder> finders) {
-    super(finders);
+  public RealDeviceProtocolImpl(String uuid, List<ResponseFinder> finders, ServerSideSession session) {
+    super(finders, session);
     IOSDevice device = null;
     try {
       device = DeviceService.get(uuid);

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/internal/SimulatorProtocolImpl.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/internal/SimulatorProtocolImpl.java
@@ -15,6 +15,7 @@ package org.uiautomation.ios.wkrdp.internal;
 
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriverException;
+import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.utils.PlistManager;
 import org.uiautomation.ios.wkrdp.ResponseFinder;
 
@@ -41,8 +42,8 @@ public class SimulatorProtocolImpl extends WebKitRemoteDebugProtocol {
   private final String LOCALHOST_IPV6 = "::1";
   private final int port = 27753;
 
-  public SimulatorProtocolImpl(List<ResponseFinder> finders) {
-    super(finders);
+  public SimulatorProtocolImpl(List<ResponseFinder> finders, ServerSideSession session) {
+    super(finders, session);
   }
 
 

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/internal/WebKitRemoteDebugProtocol.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/internal/WebKitRemoteDebugProtocol.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openqa.selenium.WebDriverException;
+import org.uiautomation.ios.ServerSideSession;
 import org.uiautomation.ios.utils.PlistManager;
 import org.uiautomation.ios.wkrdp.MessageHandler;
 import org.uiautomation.ios.wkrdp.MessageListener;
@@ -86,9 +87,8 @@ public abstract class WebKitRemoteDebugProtocol {
     listen.start();
   }
 
-
-  public WebKitRemoteDebugProtocol(List<ResponseFinder> finders) {
-    this.handler = new DefaultMessageHandler(finders);
+  public WebKitRemoteDebugProtocol(List<ResponseFinder> finders, ServerSideSession session) {
+    this.handler = new DefaultMessageHandler(finders, session);
   }
 
   public void addListener(MessageListener listener) {

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/message/MessageFactory.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/message/MessageFactory.java
@@ -32,6 +32,8 @@ import org.dom4j.DocumentException;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 
+import org.uiautomation.ios.ServerSideSession;
+
 /**
  * Created with IntelliJ IDEA. User: freynaud Date: 17/01/2013 Time: 15:08 To change this template use File | Settings |
  * File Templates.
@@ -59,7 +61,9 @@ public class MessageFactory {
 
   private Condition determiningVersion;
 
-  public MessageFactory() {
+  public MessageFactory(ServerSideSession session) {
+    iOSVersion = session.getDevice().getCapability().getSDKVersion();
+    LOG.info("GOT VERSION OF SESSION: " + iOSVersion);
     iOSTypesMap = new HashMap<>();
     versionDeterminingLock = new ReentrantLock();
     determiningVersion = versionDeterminingLock.newCondition();
@@ -176,8 +180,11 @@ public class MessageFactory {
   private void determineIOSVersion(BaseIOSWebKitMessage baseIOSWebkitMesssage) {
     try {
       versionDeterminingLock.lock();
-      iOSVersion = baseIOSWebkitMesssage.arguments.objectForKey(WebkitDevice.WIRSIMULATORPRODUCTVERSIONKEY).toString();
-      determiningVersion.signal();
+      try {
+        iOSVersion = baseIOSWebkitMesssage.arguments.objectForKey(WebkitDevice.WIRSIMULATORPRODUCTVERSIONKEY).toString();
+      } finally {
+        determiningVersion.signal();
+      }
       if (LOG.isLoggable(Level.FINE)) {
         LOG.log(Level.FINE, "IOS version determined = " + iOSVersion);
       }

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/message/MessageFactory.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/message/MessageFactory.java
@@ -42,9 +42,14 @@ public class MessageFactory {
 
   private static final List<String> DEFAULT = Arrays.asList("Default");
 
-  private static final List<String> IOS7_TYPES = Arrays.asList("7.0.3", "7.1");
+  private static final List<String> IOS7_TYPES = Arrays.asList(
+    "7.0", "7.0.1", "7.0.2", "7.0.3", "7.0.4", "7.0.5", "7.0.6", 
+    "7.1", "7.1.1", "7.1.2");
 
-  private static final List<String> IOS8_TYPES = Arrays.asList("8.0", "8.1");
+  private static final List<String> IOS8_TYPES = Arrays.asList(
+    "8.0", "8.0.1", "8.0.2", 
+    "8.1", "8.1.1", "8.1.2", "8.1.3", 
+    "8.2", "8.3", "8.4", "8.4.1");
 
   private final Map<List<String>, Map<String, Class<? extends BaseIOSWebKitMessage>>> iOSTypesMap;
 

--- a/server/src/main/java/org/uiautomation/ios/wkrdp/message/WebkitDeviceImpl.java
+++ b/server/src/main/java/org/uiautomation/ios/wkrdp/message/WebkitDeviceImpl.java
@@ -15,6 +15,7 @@
 package org.uiautomation.ios.wkrdp.message;
 
 import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
 
 public class WebkitDeviceImpl implements WebkitDevice {
 
@@ -25,9 +26,14 @@ public class WebkitDeviceImpl implements WebkitDevice {
   protected final String wirSimulatorName;
 
   public WebkitDeviceImpl(NSDictionary nSDictionary) {
-    wirSimulatorBuild = nSDictionary.objectForKey(WIRSIMULATORBUILDKEY).toString();
-    wirSimulatorProductVersion = nSDictionary.objectForKey(WIRSIMULATORPRODUCTVERSIONKEY).toString();
-    wirSimulatorName = nSDictionary.objectForKey(WIRSIMULATORNAMEKEY).toString();
+    NSObject wirSimulatorBuildObj = nSDictionary.objectForKey(WIRSIMULATORBUILDKEY);
+    NSObject wirSimulatorProductVersionObj = nSDictionary.objectForKey(WIRSIMULATORPRODUCTVERSIONKEY);
+    NSObject wirSimulatorNameObj = nSDictionary.objectForKey(WIRSIMULATORNAMEKEY);
+	// If these fields are blank, this is a physical device
+	// Leave the fields as null
+    wirSimulatorBuild = (wirSimulatorBuildObj != null) ? wirSimulatorBuildObj.toString() : "";
+    wirSimulatorProductVersion = (wirSimulatorProductVersionObj != null) ? wirSimulatorProductVersionObj.toString() : "";
+    wirSimulatorName = (wirSimulatorNameObj != null) ? wirSimulatorNameObj.toString() : "";
   }
 
   @Override


### PR DESCRIPTION
Addresses issue #384 and #369 errors when attempting to run iOS8 on a physical device, and broadens the recognized versions.

Also, changes the location of log file to where it unpacks other needed files.
