### PR TITLE
Add Support for Xcode 7 Simulator Management Quirks

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/setup/IOSSimulatorManager.java
+++ b/server/src/main/java/org/uiautomation/ios/setup/IOSSimulatorManager.java
@@ -41,7 +41,6 @@ public class IOSSimulatorManager implements IOSDeviceManager {
 
   private static final Logger log = Logger.getLogger(IOSSimulatorManager.class.getName());
 
-  public static final String SIMULATOR_PROCESS_NAME = "iPhone Simulator";
   private final List<String> sdks;
   private final String bundleId;
   private final File xcodeInstall;
@@ -103,10 +102,8 @@ public class IOSSimulatorManager implements IOSDeviceManager {
 
   @Override
   public void teardown() {
-    String simulatorName = info.getInstrumentsVersion().getMajor() < 6 ? SIMULATOR_PROCESS_NAME : "iOS Simulator";
-    ClassicCommands.killall(simulatorName);
+    simulatorSettings.killAllSimulatorApps();
   }
-
 
   private String validateSDK(String sdk) {
     if (!sdks.contains(sdk)) {

--- a/server/src/main/java/org/uiautomation/ios/utils/ClassicCommands.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/ClassicCommands.java
@@ -69,14 +69,15 @@ public class ClassicCommands {
   }
 
   public static void killall(String processName) {
-    if (isRunning(processName)) {
-      List<String> s = new ArrayList<>();
-      s.add("killall");
-      s.add(processName);
-
-      Command com = new Command(s, false);
-      com.executeAndWait(true);
+    if (!isRunning(processName)) {
+      return;
     }
+
+    List<String> s = new ArrayList<>();
+    s.add("killall");
+    s.add(processName);
+    Command com = new Command(s, false);
+    com.executeAndWait(true);
   }
 
   public static File getXCodeInstall() {


### PR DESCRIPTION
In Xcode 7 Betas the `Simulator.app` name has changed and calling `xcrun simctl erase` will fail if the Simulator is running. To guard against this, `xcrun simctl shutdown` is called before `erase`. 

I have raised a radar for what I believe is a bug (rdar://21440719), where `simctl` will not shutdown the `Simulator.app` process when the Simulator is shutdown with `xcrun simctl shutdown`. In this case `ios-driver` will retry the erase, by killing the Simulator process.
