### PR TITLE
Updated device specification on Xcode 7

### DIFF
--- a/server/src/main/java/org/uiautomation/ios/utils/AppleMagicString.java
+++ b/server/src/main/java/org/uiautomation/ios/utils/AppleMagicString.java
@@ -32,8 +32,10 @@ public class AppleMagicString {
     String specification;
     if (instrumentsVersion.getMajor() < 6) {
       specification = name + " - Simulator - iOS " + version;
-    } else {
+    } else if (instrumentsVersion.getMajor() < 7) {
       specification = name + " (" + version + " Simulator)";
+    } else {
+      specification = name + " (" + version + ")";
     }
     return specification;
   }


### PR DESCRIPTION
In xcode 7 simulator devices are named "iPhone 5s" instead of  "iPhone 5s - simulator". 
